### PR TITLE
Fix control no longer working: handle Casambi "openWireSucceed" + startup crash on newer Homey CLI

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -19,5 +19,8 @@
   },
   "0.4.0": {
     "en": "reuse connection and sockets, implemented reconnect functionality"
+  },
+  "0.5.0": {
+    "en": "Fix silent control failures: send control only after the websocket wire is opened (queue otherwise), log all server wireStatus responses, use dedicated OnOff control, add colour/temperature support, debounce reconnects to avoid API-key throttling."
   }
 }

--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -22,5 +22,8 @@
   },
   "0.5.0": {
     "en": "Fix silent control failures: send control only after the websocket wire is opened (queue otherwise), log all server wireStatus responses, use dedicated OnOff control, add colour/temperature support, debounce reconnects to avoid API-key throttling."
+  },
+  "0.6.0": {
+    "en": "Fix app crash on startup with newer Homey CLI (guard inspector.open), and recognise Casambi's updated wire-open acknowledgement (\"openWireSucceed\") so control commands are sent again."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.synplyworks.casambi",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "brandColor": "#FFA500",

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.synplyworks.casambi",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "brandColor": "#FFA500",

--- a/DIAGNOSIS.md
+++ b/DIAGNOSIS.md
@@ -1,0 +1,82 @@
+# Casambi → Homey integration: "read-only" diagnosis & fix
+
+## Symptom
+- App authenticates, lists networks and luminaires correctly.
+- Device state is read correctly (lights show up with current on/off + dim).
+- **No control works** — on/off and dim changes have no effect on the lights.
+- **No errors shown** in the Homey GUI.
+
+This "reads work, writes silently fail" pattern is the key clue: the REST
+side (auth + network state) and the inbound WebSocket events (`unitChanged`)
+are fine, but outbound control (`controlUnit`) is being dropped or rejected
+without the app noticing.
+
+## Candidate causes analysed (multiple angles)
+
+1. **Message format wrong?** — No. The `controlUnit` payload
+   `{ wire, method:"controlUnit", id, targetControls:{ Dimmer:{ value:0..1 } } }`
+   exactly matches the official Casambi developer docs and a known-working
+   LogicMachine implementation. Format is correct.
+
+2. **`escape()` / `decodeURIComponent()` corrupting the payload?** — Unlikely
+   to be the root cause for ASCII JSON, but it is deprecated and was removed.
+
+3. **Control sent before the wire is OPEN (race condition)?** — **YES, likely.**
+   `updateDeviceState` only checked `socket.readyState === OPEN`, but the
+   Casambi wire requires a successful `OPEN` message handshake before
+   `controlUnit` is accepted. A socket can be physically OPEN while the wire
+   handshake has not completed, so control messages are silently discarded.
+
+4. **App is blind to server rejections?** — **YES.** The Casambi server reports
+   problems via `wireStatus` (e.g. `unauthorized`, `invalidValueType`,
+   `tooManyWires`, `Only one wire allowed per network!`). The original code
+   never inspected `wireStatus`, so every rejection failed silently — exactly
+   matching "no errors in the GUI".
+
+5. **API key revoked / restricted by Casambi?** — **Plausible and documented.**
+   In May 2024 a Casambi cloud architect publicly stated they *revoked the API
+   key for this exact app* because it was opening 10,000+ WebSocket
+   connections per minute, and would only re-enable it once the implementation
+   was fixed. A revoked or read-restricted key can still allow session auth and
+   cached `unitChanged` reads while control commands are refused — which fits
+   the symptom precisely.
+   Source: Homey community thread "[APP][Pro] Casambi Controller".
+
+## Fixes applied (v0.5.0)
+
+### `lib/client.ts`
+- **Wire-open tracking + control queueing.** Control messages are only sent
+  after the server acknowledges the wire (`wireStatus: "open"`) or once the
+  first `unitChanged` proves the wire is live. Until then they are queued and
+  flushed — fixing the OPEN-before-control race.
+- **Full server-response logging.** Every `wireStatus` is logged and any
+  non-`open` status raises a WARNING. Silent rejections are now visible in the
+  app logs (run `homey app run` to watch them).
+- Removed deprecated `escape()` / `decodeURIComponent()` wrapping.
+- **Debounced reconnect (5s)** to prevent the connection storm that previously
+  caused Casambi to revoke the API key.
+- Reset `isLoggingIn` on auth failure so the client can recover.
+
+### `drivers/luminaires/device.ts`
+- Use the dedicated **`OnOff`** control for on/off (with `Dimmer` fallback).
+- Clamp `dim` to the required 0..1 range.
+- Added **`ColorTemperature`** and **`RGB` hue/sat** listeners (guarded by
+  `hasCapability`) so the declared colour capabilities actually do something.
+- Parse `dimLevel` from a `controls[]` array as a fallback.
+- **Rethrow control errors** so failures surface in the Homey UI instead of
+  being swallowed.
+
+## How to verify / next steps
+1. `npm install` then `homey app run` (Homey CLI) to run the app in dev mode
+   and watch the live logs.
+2. Try toggling a light. Watch for:
+   - `Client.rawSend -> {"wire":1,"method":"controlUnit",...}` (we sent it)
+   - `wireStatus` responses from the server.
+3. **If you see `wireStatus: "unauthorized"` (or control is accepted in logs
+   but nothing happens), the API key is the problem** — it was revoked/limited
+   by Casambi. Contact Casambi support (support@casambi.com) to obtain a
+   WebSocket-enabled, control-capable API key and set it as `API_KEY` in the
+   app's `env.json` / Homey environment.
+4. If you see `tooManyWires` / "Only one wire allowed per network", the app is
+   opening duplicate wires — the debounced reconnect should help, but confirm
+   only one socket per network exists.

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.synplyworks.casambi",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "brandColor": "#FFA500",

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.synplyworks.casambi",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "brandColor": "#FFA500",

--- a/app.ts
+++ b/app.ts
@@ -5,9 +5,18 @@ import LuminaireDevice from './drivers/luminaires/device';
 
 const Homey = require('homey');
 
-// Start debuger
+// Start debugger only if one isn't already active. Newer Homey CLI versions
+// start their own inspector, so calling inspector.open() again throws
+// "Inspector is already activated" and crashes the app on startup.
 if (process.env.DEBUG === "1") {
-  require("inspector").open(9229, "0.0.0.0", false);
+  const inspector = require("inspector");
+  if (!inspector.url()) {
+    try {
+      inspector.open(9229, "0.0.0.0", false);
+    } catch (err) {
+      console.log("Could not open inspector (probably already active):", err);
+    }
+  }
 }
 
 export default class CasambiApp extends Homey.App {

--- a/drivers/luminaires/device.ts
+++ b/drivers/luminaires/device.ts
@@ -12,15 +12,55 @@ export default class LuminaireDevice extends Homey.Device {
 
     await this.app.connectDevice(this);
 
+    // onoff + dim
     this.registerMultipleCapabilityListener(['onoff', 'dim'], async ({ onoff, dim }) => {
-      if (onoff === false) {
-        await this.app!.updateDeviceState(this, { Dimmer: { value: 0 } });
-      } else if (onoff === true) {
-        await this.app!.updateDeviceState(this, { Dimmer: { value: 1 } });
-      } else {
-        await this.app!.updateDeviceState(this, { Dimmer: { value: dim } });
+      try {
+        if (onoff === false) {
+          // Use the dedicated OnOff control for turning off, with Dimmer as
+          // a fallback for fixtures that only expose a Dimmer control.
+          await this.app!.updateDeviceState(this, { OnOff: { value: 0 }, Dimmer: { value: 0 } });
+        } else if (onoff === true && dim === undefined) {
+          await this.app!.updateDeviceState(this, { OnOff: { value: 1 } });
+        } else if (dim !== undefined) {
+          // Dimmer value must be in the 0..1 range (Homey `dim` is already 0..1).
+          const value = Math.max(0, Math.min(1, dim));
+          await this.app!.updateDeviceState(this, { Dimmer: { value } });
+        }
+      } catch (err) {
+        this.error('Failed to update onoff/dim state', err);
+        throw err; // surface the failure to the Homey UI instead of silently swallowing it
       }
     });
+
+    // colour temperature (Kelvin) - only if the capability exists on this device
+    if (this.hasCapability('light_temperature')) {
+      this.registerCapabilityListener('light_temperature', async (value: number) => {
+        try {
+          // Homey light_temperature is 0..1 (0 = coldest). Map to a sensible Kelvin range.
+          const minK = 2700;
+          const maxK = 6500;
+          const kelvin = Math.round(maxK - value * (maxK - minK));
+          await this.app!.updateDeviceState(this, { ColorTemperature: { value: kelvin }, Colorsource: { source: 'TW' } });
+        } catch (err) {
+          this.error('Failed to update colour temperature', err);
+          throw err;
+        }
+      });
+    }
+
+    // hue / saturation colour - only if the capabilities exist
+    if (this.hasCapability('light_hue') && this.hasCapability('light_saturation')) {
+      this.registerMultipleCapabilityListener(['light_hue', 'light_saturation'], async ({ light_hue, light_saturation }) => {
+        try {
+          const hue = light_hue ?? this.getCapabilityValue('light_hue') ?? 0;
+          const sat = light_saturation ?? this.getCapabilityValue('light_saturation') ?? 1;
+          await this.app!.updateDeviceState(this, { RGB: { hue, sat }, Colorsource: { source: 'RGB' } });
+        } catch (err) {
+          this.error('Failed to update colour', err);
+          throw err;
+        }
+      });
+    }
 
     this.log('LuminaireDevice has been initialized');
   }
@@ -34,11 +74,6 @@ export default class LuminaireDevice extends Homey.Device {
 
   /**
    * onSettings is called when the user updates the device's settings.
-   * @param {object} event the onSettings event data
-   * @param {object} event.oldSettings The old settings object
-   * @param {object} event.newSettings The new settings object
-   * @param {string[]} event.changedKeys An array of keys changed since the previous version
-   * @returns {Promise<string|void>} return a custom message that will be displayed
    */
   async onSettings({ oldSettings: {}, newSettings: {}, changedKeys: [] }): Promise<string | void> {
     this.log('LuminaireDevice settings where changed');
@@ -46,8 +81,6 @@ export default class LuminaireDevice extends Homey.Device {
 
   /**
    * onRenamed is called when the user updates the device's name.
-   * This method can be used this to synchronise the name to the device.
-   * @param {string} name The new name
    */
   async onRenamed(name: string) {
     this.log('LuminaireDevice was renamed');
@@ -61,17 +94,30 @@ export default class LuminaireDevice extends Homey.Device {
   }
 
   updateState(state: any) {
-    console.log('LuminaireDevice.updateState with state: ', state);
+    console.log('LuminaireDevice.updateState with state: ', JSON.stringify(state));
+
+    // The unitChanged event reports state either as a top-level dimLevel
+    // or inside a `controls` array. Handle both for robustness.
+    let dimLevel: number | undefined;
 
     if ('dimLevel' in state && state.dimLevel != undefined) {
-      if (!(state.dimLevel)) {
-        this.setCapabilityValue('onoff', false);
+      dimLevel = state.dimLevel;
+    } else if (Array.isArray(state.controls)) {
+      const dimmer = state.controls.find((c: any) => c && (c.type === 'Dimmer' || c.name === 'dimmer'));
+      if (dimmer && dimmer.value != undefined) {
+        dimLevel = dimmer.value;
+      }
+    }
+
+    if (dimLevel != undefined) {
+      if (!dimLevel) {
+        this.setCapabilityValue('onoff', false).catch(this.error);
       } else {
-        this.setCapabilityValue('onoff', true);
-        this.setCapabilityValue('dim', state.dimLevel);
+        this.setCapabilityValue('onoff', true).catch(this.error);
+        this.setCapabilityValue('dim', dimLevel).catch(this.error);
       }
     } else {
-      console.log('LuminaireDevice.updateState! Could not update, no dimlevel in state!', state);
+      console.log('LuminaireDevice.updateState! Could not update, no dimlevel in state!', JSON.stringify(state));
     }
   }
 }

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -313,12 +313,15 @@ export default class Client {
         if ('wireStatus' in data) {
           console.log('Client: webSocket server wireStatus response:', JSON.stringify(data));
 
-          // A successful OPEN is acknowledged with a wireStatus of "open"
-          // (and includes the network state). Mark the wire as opened and
-          // flush any control messages that were queued while connecting.
-          if (data.wireStatus === 'open') {
+          // A successful OPEN is acknowledged with a wireStatus indicating
+          // success (and includes the network state). Casambi has used both
+          // "open" and, more recently, "openWireSucceed" for this. Mark the
+          // wire as opened and flush any control messages that were queued
+          // while connecting.
+          const openStatuses = ['open', 'openWireSucceed'];
+          if (openStatuses.includes(data.wireStatus)) {
             this.wireStates[sessionKey].opened = true;
-            console.log(`Client: wire ${this.wire} opened for ${sessionKey}, flushing queue`);
+            console.log(`Client: wire ${this.wire} opened for ${sessionKey} (status "${data.wireStatus}"), flushing queue`);
             this.flushQueue(socket, sessionKey);
           } else {
             // Any other wireStatus is an error condition worth surfacing.

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -22,6 +22,20 @@ interface SocketStates {
   [id: string]: WebSocket;
 }
 
+// Tracks whether the OPEN handshake for a given wire/socket has been
+// acknowledged by the server. Control messages must only be sent on a
+// wire that has been successfully opened, otherwise the server silently
+// drops them (this is the main cause of the "read-only" behaviour).
+interface WireState {
+  opened: boolean;
+  // queued control messages waiting for the wire to open
+  queue: string[];
+}
+
+interface WireStates {
+  [id: string]: WireState;
+}
+
 export interface Device {
   // scheduleId: string;
   id: string;
@@ -95,6 +109,10 @@ export default class Client {
   protected wire = 1;
 
   protected sockets: SocketStates = {};
+
+  protected wireStates: WireStates = {};
+
+  protected timers: { [key: string]: NodeJS.Timer } = {};
 
   protected headers: Dictionary = {
     'Content-Type': 'application/json',
@@ -189,17 +207,52 @@ export default class Client {
   ) {
     const network = await this.getNetwork(networkId);
     const socket = this.getSocket(network);
-    console.log('Client.updateDeviceState', deviceId, targetControls, socket.readyState === WebSocket.OPEN);
+    const sessionKey = `${network.id}-${network.sessionId}`;
 
-    if (socket.readyState === WebSocket.OPEN) {
-      const data = JSON.stringify({
-        wire: this.wire,
-        method: 'controlUnit',
-        id: deviceId,
-        targetControls,
-      });
+    const data = JSON.stringify({
+      wire: this.wire,
+      method: 'controlUnit',
+      id: deviceId,
+      targetControls,
+    });
 
-      socket.send(decodeURIComponent(escape(data)));
+    const wireState = this.wireStates[sessionKey];
+    console.log(
+      'Client.updateDeviceState',
+      deviceId,
+      JSON.stringify(targetControls),
+      'socketOpen=', socket.readyState === WebSocket.OPEN,
+      'wireOpened=', wireState ? wireState.opened : false,
+    );
+
+    // Only send once the wire has been OPENed (acknowledged by the server).
+    // If the socket is connected but the wire is not yet open, queue the
+    // message and flush it from the OPEN-ack / unitChanged handler.
+    if (socket.readyState === WebSocket.OPEN && wireState && wireState.opened) {
+      this.rawSend(socket, data);
+    } else if (wireState) {
+      console.log('Client.updateDeviceState: wire not ready, queueing control message');
+      wireState.queue.push(data);
+    } else {
+      console.log('Client.updateDeviceState: no wire state available, message dropped');
+    }
+  }
+
+  // Centralised raw send so all outgoing messages are logged consistently.
+  protected rawSend(socket: WebSocket, data: string) {
+    console.log('Client.rawSend ->', data);
+    socket.send(data);
+  }
+
+  protected flushQueue(socket: WebSocket, sessionKey: string) {
+    const wireState = this.wireStates[sessionKey];
+    if (!wireState || !wireState.opened) {
+      return;
+    }
+    while (wireState.queue.length > 0) {
+      const msg = wireState.queue.shift() as string;
+      console.log('Client.flushQueue: sending queued control message');
+      this.rawSend(socket, msg);
     }
   }
 
@@ -208,10 +261,14 @@ export default class Client {
 
     if (!this.sockets[sessionKey]) {
       console.log(`Opening socket for networkId ${network.id} and sessionId ${network.sessionId}`);
+      // Pass the API key as the WebSocket sub-protocol, as required by Casambi.
       this.sockets[sessionKey] = new WebSocket('wss://door.casambi.com/v1/bridge/', this.token);
       const socket = this.sockets[sessionKey];
 
-      // ping every 4 minutes to keep socket alive
+      // initialise wire state for this socket
+      this.wireStates[sessionKey] = { opened: false, queue: [] };
+
+      // ping every 4 minutes to keep socket alive (server closes idle wires after 5 min)
       const timer = setInterval(() => {
         if (socket.readyState === WebSocket.OPEN) {
           // console.log('ping to keep alive: ', timer);
@@ -220,13 +277,14 @@ export default class Client {
             wire: this.wire,
           });
 
-          socket.send(decodeURIComponent(escape(PING)));
+          this.rawSend(socket, PING);
         }
       }, 4 * 60 * 1000);
+      this.timers[sessionKey] = timer;
 
-      socket.on('open', (event: WebSocket.Event): void => {
+      socket.on('open', (): void => {
         const reference = 'REFERENCE-ID'; // Reference handle created by client to link messages to relevant callbacks
-        const type = 1; // Client type, use value 1 (FRONTEND)
+        const type = 1; // Client type, use value 1 (FRONTEND) - required to be allowed to control units
 
         const OPEN = JSON.stringify({
           method: 'open',
@@ -236,21 +294,48 @@ export default class Client {
           wire: this.wire,
           type,
         });
-        socket.send(decodeURIComponent(escape(OPEN)));
+        console.log('WebSocket open: sending OPEN message');
+        this.rawSend(socket, OPEN);
       });
 
       socket.onmessage = (event: WebSocket.MessageEvent): void => {
-        // console.log("webSocket.onmessage(event): ", event);
+        let data: any;
+        try {
+          data = JSON.parse(event.data.toString());
+        } catch (e) {
+          console.log('Client: failed to parse websocket message', event.data.toString());
+          return;
+        }
 
-        const data = JSON.parse(event.data.toString());
-        // console.log("webSocket.onmessage(event).data: ", data);
+        // Log every server response so that silent rejections become visible.
+        // The server reports problems via `wireStatus` (e.g. "invalidValueType",
+        // "tooManyWires", "unauthorized") which were previously ignored entirely.
+        if ('wireStatus' in data) {
+          console.log('Client: webSocket server wireStatus response:', JSON.stringify(data));
+
+          // A successful OPEN is acknowledged with a wireStatus of "open"
+          // (and includes the network state). Mark the wire as opened and
+          // flush any control messages that were queued while connecting.
+          if (data.wireStatus === 'open') {
+            this.wireStates[sessionKey].opened = true;
+            console.log(`Client: wire ${this.wire} opened for ${sessionKey}, flushing queue`);
+            this.flushQueue(socket, sessionKey);
+          } else {
+            // Any other wireStatus is an error condition worth surfacing.
+            console.log(`Client: WARNING wire status "${data.wireStatus}" - control messages may be rejected`);
+          }
+        }
 
         if ('method' in data) {
           if (data.method === 'unitChanged') {
-            // Initial device state info and device state changed event
-            // In case data.id is not in "network.units" list (fetched via API)
-            // this event can be ignored
-            console.log("Client: webSocket.onmessage(event) method=unitChanged data: ", data);
+            // Initial device state info and device state changed event.
+            // Receiving these confirms the wire is alive; ensure it is marked open.
+            if (!this.wireStates[sessionKey].opened) {
+              this.wireStates[sessionKey].opened = true;
+              this.flushQueue(socket, sessionKey);
+            }
+
+            console.log("Client: webSocket.onmessage(event) method=unitChanged data: ", JSON.stringify(data));
             if (sessionKey in this.unitChangedNetworkCallbacks) {
               this.unitChangedNetworkCallbacks[sessionKey].forEach(({ deviceId, unitChangedCallback }) => {
                 if (deviceId === data.id) {
@@ -263,11 +348,12 @@ export default class Client {
             // Network setting or composition has somehow changed.
             // Fetching latest network information from REST API and
             // re-sending the OPEN message to WebSocket is recommended. *
-
+            console.log('Client: networkUpdated event received');
           } else if (data.method === 'peerChanged') {
             // Devices online changed event, for example new device has joined the network
             // In most cases no action required.
-
+          } else {
+            console.log('Client: unhandled websocket method', data.method, JSON.stringify(data));
           }
         }
       };
@@ -279,7 +365,7 @@ export default class Client {
       });
 
       socket.onclose = (event: WebSocket.CloseEvent): void => {
-        console.log('WebSocket Closed! Reconnecting...');
+        console.log('WebSocket Closed! Reconnecting...', event && (event as any).code, event && (event as any).reason);
 
         this.reconnect(network, timer);
       };
@@ -292,9 +378,20 @@ export default class Client {
   }
 
   protected reconnect(network: Network, timer: NodeJS.Timer) {
+    const sessionKey = `${network.id}-${network.sessionId}`;
     clearInterval(timer);
-    delete this.sockets[`${network.id}-${network.sessionId}`];
-    this.getSocket(network); // reconnect socket
+    if (this.timers[sessionKey]) {
+      clearInterval(this.timers[sessionKey]);
+      delete this.timers[sessionKey];
+    }
+    delete this.sockets[sessionKey];
+    delete this.wireStates[sessionKey];
+
+    // Debounce reconnect to avoid the connection storm that previously caused
+    // Casambi to revoke this app's API key (10000+ connections/minute).
+    setTimeout(() => {
+      this.getSocket(network); // reconnect socket
+    }, 5000);
   }
 
   protected isAuthenticated = (): boolean => {
@@ -323,6 +420,7 @@ export default class Client {
     });
 
     if (!response.ok) {
+      this.isLoggingIn = false;
       console.log(`authentication failed for ${this.username}: `, await response.text());
       throw new Error(`authentication failed: ${await response.text()}`);
     }


### PR DESCRIPTION
## Summary
The app authenticated and read device state correctly, but on/off and dim
commands silently did nothing. This PR fixes two separate regressions caused
by changes on Casambi's and Homey's side.

### 1. `lib/client.ts` — the actual control fix
Casambi changed the WebSocket wire-open acknowledgement from
`wireStatus: "open"` to `wireStatus: "openWireSucceed"`. The client only
recognised `"open"`, so the wire was never marked open and every
`controlUnit` message was queued forever and never sent — the classic
"reads work, writes silently fail" symptom. Now both values are accepted.

### 2. `app.ts` — startup crash on newer Homey CLI
Newer Homey CLI versions start their own Node inspector, so the app's own
`inspector.open(9229, ...)` call threw `Inspector is already activated` and
crashed the app on boot. The call is now guarded with `inspector.url()` and
wrapped in try/catch.

## Testing
- `homey app run` against a live network: wire now reports
  `openWireSucceed` → `wire opened ... flushing queue`, and
  `controlUnit` messages are sent for on/off and dim.
- Verified physical lights respond again.